### PR TITLE
Append foo at end of current readme...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 Codestub.ai
 codestub.ai
 codestub.ai
+foo


### PR DESCRIPTION
To append "foo" at the end of the current README file, you can use the `echo` command in a terminal. Here's how you can do it:

```bash
echo "foo" >> README.md
```

This command will append the string "foo" at the end of the README.md file. If the file does not exist, it will be created.